### PR TITLE
Add TDD agent eval benchmark harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .github/bin/
 dist/
+results/

--- a/TDD-Harness-Plan.md
+++ b/TDD-Harness-Plan.md
@@ -2,24 +2,19 @@
 
 ## Overview
 
-This file is the lightweight index for implementation.
-Detailed build instructions are split into issue-specific files so implementation agents only load the issue they are executing.
+This is the lightweight index for implementing the Copilot TDD harness.
+Detailed implementation content has been split into issue-specific documents so agents can load only the issue they are working on.
 
-## Archived Full Plan
+## How To Use This Plan
 
-The full monolithic reference has been preserved at:
-- [Full plan archive](docs/TDD-Harness-Plan.full.md)
-
-## How To Use
-
-1. Choose the GitHub issue you are implementing.
-2. Read only that issue detail file.
-3. Implement directly from that file.
-4. Use this index only for cross-cutting context.
+1. Pick a GitHub issue.
+2. Open only that issue document from the list below.
+3. Implement from that document.
+4. Use this file only for high-level architecture and cross-cutting context.
 
 ---
 
-## Issue-Specific Detail Docs
+## Issue Documents (Primary Implementation Sources)
 
 - [Issue #1 - tdd-setup skill](docs/issue-plans/issue-1-tdd-setup-skill.md)
 - [Issue #2 - always-on rules and config](docs/issue-plans/issue-2-always-on-rules-and-config.md)
@@ -30,26 +25,98 @@ The full monolithic reference has been preserved at:
 - [Issue #7 - safe install scripts](docs/issue-plans/issue-7-safe-install-scripts.md)
 - [Issue #8 - verification suite](docs/issue-plans/issue-8-verification-suite.md)
 - [Issue #9 - agent plugin packaging](docs/issue-plans/issue-9-agent-plugin-packaging.md)
+- [Issue #10 - eval benchmark matrix for TDD agent behavior](docs/issue-plans/issue-10-eval-plan-for-tdd-agent-behavior.md)
 
 ---
 
-## Architecture (Cross-Cutting)
+## Research Foundations
+
+Nine LLM research papers (2022-2025) inform the design decisions:
+
+| Paper | Year | Key Finding | Applied As |
+|-------|------|------------|-----------|
+| ReAct (Yao et al) | 2022 | Interleaved reasoning+acting reduces hallucination | Mandatory phase declaration block before every file action |
+| Constitutional AI (Bai et al) | 2022 | Hierarchical rules + self-critique without human labels | Per-phase self-critique checklist at end of each agent body |
+| Reflexion (Shinn et al) | 2023 | Verbal reinforcement (91% pass@1 on HumanEval) | Structured narrative feedback from PostToolUse hook |
+| Lost in the Middle (Liu et al) | 2023 | Middle of context is ignored; start+end attended | TDD constraints repeated at top AND bottom of each agent |
+| SWE-agent / ACI (Yang et al) | 2024 | ACI design is #1 performance factor (12.5x improvement) | Structured JSON output from hook scripts, not raw stdout |
+| ReST-MCTS* / PRM (Zhang et al) | 2024 | Step-level rewards outperform outcome-only rewards | Two-level reward: PostToolUse (step) + Stop hook (terminal) |
+| TheAgentCompany (Xu et al) | 2024 | Long-horizon tasks fail most (30% completion) | Each phase agent scoped to ONE behavior per session |
+| SWE-RL (Wei et al) | 2025 | Binary pass/fail is sufficient rule-based reward | Deterministic test-pass hook is the correct reward signal |
+| START hint injection (Li et al) | 2025 | Brief hints during inference stimulate tool use | UserPromptSubmit hook injects one-line phase reminder |
+
+---
+
+## Architecture - 5 Layers
 
 ```
-Repository Governance              .github/settings.yml
 Layer 1: Always-On Rules          .github/instructions/tdd-constitution.instructions.md
 Layer 2: Project Configuration    .github/tdd-config.json
                                   .github/instructions/tdd-patterns.instructions.md
 Layer 3: Phase Agents             .github/agents/tdd-{red,green,commit,refactor}.agent.md
 Layer 4: Lifecycle Hooks          .github/hooks/tdd-enforcement.json
                                   scripts/tdd-run-tests.{ps1,sh}
-                                  cmd/tdd-run-tests (Go CLI)
 Layer 5: On-Demand Access         .github/skills/tdd-workflow/SKILL.md
                                   .github/skills/tdd-setup/SKILL.md
                                   .github/prompts/tdd-{start,status}.prompt.md
 ```
 
+---
+
+## Complete File Structure (Target)
+
+```
+.github/
+  instructions/
+    tdd-constitution.instructions.md
+    tdd-patterns.instructions.md
+  tdd-config.json
+  agents/
+    tdd-red.agent.md
+    tdd-green.agent.md
+    tdd-commit.agent.md
+    tdd-refactor.agent.md
+  hooks/
+    tdd-enforcement.json
+  skills/
+    tdd-workflow/
+      SKILL.md
+    tdd-setup/
+      SKILL.md
+      templates/
+        dotnet.tdd-patterns.md
+        node.tdd-patterns.md
+        python.tdd-patterns.md
+        java.tdd-patterns.md
+  prompts/
+    tdd-start.prompt.md
+    tdd-status.prompt.md
+scripts/
+  tdd-run-tests.ps1
+  tdd-run-tests.sh
+  tdd-scan.ps1
+  tdd-scan.sh
+  install-tdd-harness.ps1
+  install-tdd-harness.sh
+plugin.json
+copilot-tdd-harness.nuspec
+TDD-Framework.md
+```
+
+---
+
+## Cross-Cutting References
+
+For enforcement behavior, implementation constraints, and acceptance criteria, use issue documents as source of truth:
+
+- Hooks and reward model: [Issue #5](docs/issue-plans/issue-5-lifecycle-hooks-and-test-reward.md)
+- Agent handoffs and phase contracts: [Issue #4](docs/issue-plans/issue-4-phase-agents-and-handoffs.md)
+- Verification checklist: [Issue #8](docs/issue-plans/issue-8-verification-suite.md)
+- Packaging and distribution: [Issue #9](docs/issue-plans/issue-9-agent-plugin-packaging.md)
+
+---
+
 ## Notes
 
-- Source of truth for implementation detail is the issue-specific docs.
-- This index intentionally avoids phase-by-phase build instructions.
+- This file intentionally avoids full phase implementation details.
+- If an agent is implementing an issue, it should read only the corresponding issue document above.

--- a/cmd/tdd-eval-run/main.go
+++ b/cmd/tdd-eval-run/main.go
@@ -1,0 +1,82 @@
+// Command tdd-eval-run produces a deterministic run-summary JSON document
+// for a TDD agent benchmark run by analyzing the git history of a workspace
+// against a known baseline ref. The output conforms to v1 of
+// evals/schema/run-summary.schema.json.
+//
+// Example:
+//
+//	tdd-eval-run summarize \
+//	  --workspace ./samples/calculator-cli-go \
+//	  --baseline baseline \
+//	  --fixture-id calculator-cli-go \
+//	  --scenario-id feature-add-subtract-command \
+//	  --scenario-family feature \
+//	  --run-mode micro-cycle \
+//	  --tests-passed-at-end \
+//	  > run-summary.json
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mrlarson2007/copilot-tdd-harness/internal/evalrun"
+)
+
+func main() {
+	if len(os.Args) < 2 || os.Args[1] != "summarize" {
+		fmt.Fprintln(os.Stderr, "usage: tdd-eval-run summarize [flags]")
+		os.Exit(2)
+	}
+
+	fs := flag.NewFlagSet("summarize", flag.ExitOnError)
+	workspace := fs.String("workspace", "", "path to git workspace where the run took place")
+	baseline := fs.String("baseline", "", "git ref (sha/tag/branch) marking the start of the run")
+	fixtureID := fs.String("fixture-id", "", "fixture identifier (matches a directory under samples/)")
+	baselineID := fs.String("baseline-id", "", "scenario-declared baseline identifier (optional)")
+	scenarioID := fs.String("scenario-id", "", "scenario identifier")
+	scenarioFamily := fs.String("scenario-family", "", "scenario family: feature|validation|bug-fix|refactor-only|ambiguous|longitudinal")
+	runMode := fs.String("run-mode", "micro-cycle", "run mode: micro-cycle|longitudinal")
+	prompt := fs.String("prompt", "", "user prompt used for the run (verbatim)")
+	clarificationAsked := fs.Bool("clarification-asked", false, "whether the agent asked a clarifying question")
+	clarificationExpected := fs.Bool("clarification-expected", false, "whether the scenario expected a clarifying question")
+	testsPassedAtEnd := fs.Bool("tests-passed-at-end", false, "verified test outcome at HEAD")
+	testRunCount := fs.Int("test-run-count", 0, "number of test executions observed during the run")
+	firstFailingTestName := fs.String("first-failing-test", "", "name of the first failing test observed")
+	notes := fs.String("notes", "", "free-form notes (optional)")
+	_ = fs.Parse(os.Args[2:])
+
+	if *workspace == "" || *baseline == "" || *fixtureID == "" || *scenarioID == "" || *scenarioFamily == "" {
+		fmt.Fprintln(os.Stderr, "summarize: --workspace, --baseline, --fixture-id, --scenario-id, --scenario-family are required")
+		os.Exit(2)
+	}
+
+	summary, err := evalrun.Summarize(evalrun.Opts{
+		WorkspaceDir:          *workspace,
+		BaselineRef:           *baseline,
+		FixtureID:             *fixtureID,
+		BaselineID:            *baselineID,
+		ScenarioID:            *scenarioID,
+		ScenarioFamily:        *scenarioFamily,
+		RunMode:               *runMode,
+		Prompt:                *prompt,
+		ClarificationAsked:    *clarificationAsked,
+		ClarificationExpected: *clarificationExpected,
+		TestsPassedAtEnd:      *testsPassedAtEnd,
+		TestRunCount:          *testRunCount,
+		FirstFailingTestName:  *firstFailingTestName,
+		Notes:                 *notes,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "summarize: %v\n", err)
+		os.Exit(1)
+	}
+
+	out, err := evalrun.MarshalJSON(summary)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "marshal: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(out))
+}

--- a/cmd/tdd-run-tests/main.go
+++ b/cmd/tdd-run-tests/main.go
@@ -16,7 +16,7 @@ func main() {
 		writeJSON(map[string]any{
 			"event":    "Error",
 			"decision": "continue",
-			"message":  "Unsupported mode: " + strings.TrimSpace(modeValue) + ". Supported modes are hint, step, terminal, state, status.",
+			"message":  "Unsupported mode: " + strings.TrimSpace(modeValue) + ". Supported modes are hint, step, terminal, state, status, eval.",
 		})
 		return
 	}

--- a/docs/TDD-Harness-Plan.full.md
+++ b/docs/TDD-Harness-Plan.full.md
@@ -19,6 +19,7 @@ Use these focused docs when implementing a single GitHub issue so the agent only
 - [Issue #7 — safe install scripts](docs/issue-plans/issue-7-safe-install-scripts.md)
 - [Issue #8 — verification suite](docs/issue-plans/issue-8-verification-suite.md)
 - [Issue #9 — agent plugin packaging](docs/issue-plans/issue-9-agent-plugin-packaging.md)
+- [Issue #10 — eval benchmark matrix for TDD agent behavior](docs/issue-plans/issue-10-eval-plan-for-tdd-agent-behavior.md)
 
 ---
 
@@ -713,3 +714,33 @@ After installation, verify the harness is working:
 4. **Skill portability**: Skills in `.github/skills/` are portable across VS Code, GitHub Copilot CLI, and any Copilot-powered editor that supports the agent skills open standard (agentskills.io). No vendor lock-in beyond the hook format.
 
 5. **Progressive adoption**: Teams can adopt the harness incrementally — start with just the constitution (Layer 1) for minimal enforcement, add hooks later for automated feedback, add phase agents when the team is ready for guided workflow. Each layer is independently deployable.
+
+---
+
+## Phase 8 — Eval Benchmark Matrix ([#20](https://github.com/mrlarson2007/copilot-tdd-harness/issues/20))
+
+The harness needs a benchmark that measures whether agents actually preserve TDD discipline as task pressure changes. Do not treat this only as an easy/medium/hard ladder. That loses too much diagnostic information.
+
+Instead, structure evaluation as a matrix:
+
+1. **Fixture families**
+  - tiny function/library fixture (`fizzbuzz-go`)
+  - CLI fixture (`calculator-cli-go`)
+  - stateful fixture (`todo-cli-go` or equivalent)
+2. **Scenario families**
+  - feature addition
+  - validation edge case
+  - bug-fix regression
+  - refactor-only
+  - ambiguous requirement requiring clarification
+  - multi-cycle longitudinal drift
+
+The unit of evaluation is one scenario from one known baseline. The harness runner owns fixture reset, agent invocation, and artifact capture. Promptfoo Community/local mode owns scoring and aggregation over a structured run-summary JSON contract.
+
+V1 should prioritize deterministic signals such as:
+- whether a failing test was added before production code changed
+- whether all tests pass at the end of the cycle
+- whether clarification was requested when ambiguity was expected
+- whether commits keep test and production changes together
+
+The proof of concept should stay small: `fizzbuzz-go` as a smoke fixture, `calculator-cli-go` as the first real benchmark target, and one stateful fixture reserved for longer-horizon drift scenarios.

--- a/docs/issue-plans/issue-10-eval-plan-for-tdd-agent-behavior.md
+++ b/docs/issue-plans/issue-10-eval-plan-for-tdd-agent-behavior.md
@@ -1,0 +1,251 @@
+# Detailed Issue Plan
+
+This file contains the detailed implementation content for this single GitHub issue, extracted from the master plan.
+
+## Issue #10 — Eval Benchmark Matrix for TDD Agent Behavior ([#20](https://github.com/mrlarson2007/copilot-tdd-harness/issues/20))
+
+### Goal
+
+Evaluate how consistently coding agents follow TDD across different change types, fixture families, and session lengths. The benchmark must measure TDD process fidelity, not just whether the final task was completed.
+
+### Core Design Shift
+
+Do **not** organize the benchmark only as an easy/medium/hard ladder.
+
+That structure is too coarse and mixes together multiple factors:
+- repo complexity
+- task familiarity
+- bug-fix vs feature work
+- ambiguity handling
+- statefulness
+- long-horizon drift
+
+Instead, use a **benchmark matrix**:
+- **Fixture families** define the kind of codebase being changed.
+- **Scenario families** define the kind of behavioral pressure being applied.
+- **Run modes** distinguish between single-cycle discipline and multi-cycle drift.
+
+### Deliverables
+
+Implement a Promptfoo-backed evaluation harness that includes:
+- a benchmark matrix, not just a difficulty ladder
+- a deterministic run-summary JSON schema derived from artifacts
+- a small starter fixture set
+- repeatable run protocol from clean baselines
+- rubric scoring for TDD fidelity, task correctness, and commit quality
+- a holdout set for prompt-tuning resistance
+
+### V1 Benchmark Structure
+
+#### 1) Fixture Families
+
+Start with three fixture families:
+
+1. **Tiny function/library fixture**
+   - Example: `samples/fizzbuzz-go`
+   - Purpose: smoke-test the TDD loop on a tiny codebase with minimal setup noise.
+2. **CLI fixture**
+   - Example: a new `calculator-cli-go`
+   - Purpose: exercise argument parsing, validation, exit codes, and multiple commands.
+3. **Stateful fixture**
+   - Example: a new `todo-cli-go`
+   - Purpose: exercise persistence, multi-step workflows, invalid states, and longer reasoning chains.
+
+#### 2) Scenario Families
+
+Each fixture family should eventually support these scenario families:
+
+1. **Feature addition**
+   - Add one new behavior from a clean baseline.
+2. **Validation edge case**
+   - Add or fix handling for invalid input, missing data, or malformed usage.
+3. **Bug-fix regression**
+   - Start from a repo state where a failing regression already exists.
+4. **Refactor-only**
+   - Require improvement without externally observable behavior changes.
+5. **Ambiguous requirement**
+   - Require the agent to ask for clarification before coding.
+6. **Longitudinal drift**
+   - Run several TDD cycles in the same fixture to see whether discipline decays over time.
+
+#### 3) Run Modes
+
+Support two run modes:
+
+1. **Micro-cycle run**
+   - One behavior from one clean baseline.
+   - Purpose: measure isolated RED → GREEN → COMMIT → REFACTOR discipline.
+2. **Longitudinal run**
+   - Multiple behavior changes in sequence inside the same fixture.
+   - Purpose: measure whether TDD fidelity degrades as context and repo state grow.
+
+### Starter Matrix (V1)
+
+Use a small but diagnostic matrix first.
+
+| Fixture | Feature | Validation | Bug-fix | Refactor-only | Ambiguous | Longitudinal |
+|---------|---------|------------|---------|---------------|-----------|--------------|
+| `fizzbuzz-go` | yes | optional | no | no | no | no |
+| `calculator-cli-go` | yes | yes | yes | optional | yes | yes |
+| `todo-cli-go` | yes | yes | yes | yes | yes | yes |
+
+Notes:
+- `fizzbuzz-go` is a smoke fixture only. Do not over-index on it.
+- `calculator-cli-go` is the first real benchmark target.
+- `todo-cli-go` or equivalent stateful fixture is the first long-horizon stress target.
+
+### Evaluation Unit
+
+The unit of evaluation is **one scenario from one known baseline**, not “solve the whole app.”
+
+Each scenario must specify:
+- fixture identifier
+- baseline snapshot identifier
+- scenario identifier
+- scenario family
+- user prompt
+- expected TDD constraints
+- whether clarification is expected
+- whether this run is micro-cycle or longitudinal
+
+### Run Protocol
+
+Per scenario:
+
+1. Start from a clean fixture snapshot.
+2. Invoke the agent loop with one behavior prompt.
+3. Capture transcript, file edits, git changes, test output, and optional coverage.
+4. Produce a run-summary JSON file from those artifacts.
+5. Score the run via Promptfoo assertions over the summary JSON.
+6. Reset to the same baseline for comparison runs.
+
+For longitudinal runs:
+
+1. Start from a clean fixture snapshot.
+2. Execute a predefined sequence of behavior prompts.
+3. Capture per-cycle artifacts plus an end-of-run aggregate summary.
+4. Score both per-cycle fidelity and drift over time.
+
+### Architecture Split
+
+Use **two layers**, with clear ownership:
+
+1. **Harness runner owns execution and artifact capture**
+   - fixture checkout/copy
+   - agent invocation
+   - transcript collection
+   - git history capture
+   - test and coverage execution
+   - run-summary JSON generation
+2. **Promptfoo owns scoring and aggregation**
+   - custom provider invokes the harness runner
+   - assertions inspect structured JSON output
+   - derived metrics aggregate results across runs
+
+This keeps Promptfoo as the scoring layer, not the entire orchestration layer.
+
+### Required Run-Summary JSON Schema
+
+The run-summary schema is the main contract between the harness and Promptfoo.
+
+V1 must include fields such as:
+- `fixtureId`
+- `scenarioId`
+- `scenarioFamily`
+- `runMode`
+- `prompt`
+- `phaseTransitions`
+- `clarificationAsked`
+- `newTestsAdded`
+- `productionFilesChanged`
+- `productionChangedBeforeFirstFailingTest`
+- `testsPassedAtEnd`
+- `testRunCount`
+- `firstFailingTestName`
+- `commitCount`
+- `testAndCodeCommittedTogether`
+- `coverageDelta` (optional in V1 if unavailable)
+- `failureModes`
+- `notes`
+
+The schema should prefer artifact-derived facts over model self-report.
+
+### Scoring Model
+
+Keep TDD fidelity separate from general task completion.
+
+#### Recommended V1 Weighting
+
+1. **Protocol fidelity** — 50%
+   - RED before production code
+   - one behavior per cycle
+   - all tests green before refactor/commit transition
+   - no refactor while tests fail
+2. **Task correctness** — 25%
+   - requested behavior implemented correctly
+   - required validation or bug-fix actually works
+3. **Commit quality** — 15%
+   - commit boundaries are small and understandable
+   - test + production code committed together when commits exist
+4. **Code quality / coverage movement** — 10%
+   - duplication not worsened materially
+   - coverage or direct test support improved for changed behavior
+
+#### Deterministic First, Heuristic Later
+
+V1 should prefer deterministic measures where possible:
+- did a failing test appear before production changes?
+- did all tests pass at the end?
+- was clarification asked when expected?
+- were commits behavior-scoped?
+
+Coverage and code quality can begin with lighter-weight heuristics and be improved later.
+
+### Holdout Strategy
+
+Do not tune prompts only against the public benchmark set.
+
+Maintain:
+- **development scenarios** used during harness implementation and prompt tuning
+- **holdout scenarios** used only for benchmark reporting
+
+Without a holdout set, the eval becomes a tuning target instead of a trustworthy measurement.
+
+### Proof-of-Concept Scope
+
+The first working slice should be intentionally small:
+
+1. `fizzbuzz-go` smoke scenarios
+2. one `calculator-cli-go` feature scenario
+3. one `calculator-cli-go` validation scenario
+4. one deterministic Promptfoo scoring configuration over run-summary JSON
+
+Do **not** attempt to cover all scenario families before the runner and schema are stable.
+
+### Non-Goals for V1
+
+V1 should explicitly avoid:
+- hosted Promptfoo dependencies
+- production monitoring
+- generic RAG or chat quality metrics
+- provider-specific eval stacks such as OpenAI Evals as the primary path
+- scoring whole-app generation in one prompt
+
+### Acceptance Criteria
+
+- A benchmark matrix exists across fixture families and scenario families.
+- The benchmark is organized around one-scenario-from-one-baseline runs.
+- A run-summary JSON schema exists and is artifact-derived.
+- Promptfoo Community/local mode is the documented scoring framework for v1.
+- The proof-of-concept includes both smoke and real benchmark scenarios.
+- The plan distinguishes micro-cycle fidelity from longitudinal drift.
+- A holdout strategy is defined to reduce benchmark gaming.
+
+### Recommended Implementation Order
+
+1. Define the run-summary JSON schema.
+2. Add the first real CLI fixture (`calculator-cli-go`).
+3. Implement fixture reset + scenario runner plumbing.
+4. Score deterministic TDD signals with Promptfoo.
+5. Add one ambiguity scenario and one bug-fix scenario.
+6. Add one longitudinal multi-cycle run.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,158 @@
+# TDD Agent Evaluation Harness
+
+This directory contains the evaluation harness for the TDD agent workflow.
+The design follows the benchmark matrix described in
+[`docs/issue-plans/issue-10-eval-plan-for-tdd-agent-behavior.md`](../docs/issue-plans/issue-10-eval-plan-for-tdd-agent-behavior.md).
+
+## Layout
+
+```
+evals/
+  schema/
+    run-summary.schema.json   # v1 contract between harness runner and Promptfoo
+  scenarios/
+    <fixtureId>/
+      <scenarioId>.yaml       # one evaluation unit (one scenario, one baseline)
+  fixtures/
+    run-summaries/            # synthetic run-summaries used to exercise scoring
+  promptfoo/
+    promptfooconfig.yaml      # legacy v0 scaffold (validates runner eval payload)
+    promptfoo-benchmark.yaml  # v1 benchmark matrix scoring config
+    benchmark-provider.js     # reads run-summary JSON and returns it as output
+    assertions/               # deterministic scoring assertions
+```
+
+## Architecture
+
+Two layers, with clear ownership:
+
+1. **Harness runner** (planned, not yet wired) owns execution and artifact
+   capture: fixture checkout, agent invocation, transcript collection, git
+   history capture, test/coverage execution, and run-summary JSON generation.
+2. **Promptfoo** owns scoring and aggregation: the custom provider invokes
+   the harness runner (or, for now, reads a pre-produced run-summary JSON
+   file), and the assertions inspect the structured output.
+
+## Run-summary JSON contract
+
+Every benchmark run produces a single run-summary JSON document conforming to
+[`schema/run-summary.schema.json`](./schema/run-summary.schema.json). The
+schema is the **only** contract between the two layers. Prefer
+artifact-derived facts (git history, test exit codes, file diffs) over model
+self-report.
+
+Key fields used by the v1 deterministic scoring layer:
+
+- `productionChangedBeforeFirstFailingTest` — central RED-before-production
+  signal.
+- `testsPassedAtEnd` — final-state correctness.
+- `testAndCodeCommittedTogether` — commit boundary signal.
+- `clarificationAsked` — combined with the scenario manifest's
+  `clarificationExpected`.
+- `failureModes` — structured list of detected fidelity failures.
+
+## Scenario manifests
+
+Each scenario is one evaluation unit: **one scenario from one known baseline**.
+See [`scenarios/fizzbuzz-go/feature-add-divisible-by-seven.yaml`](./scenarios/fizzbuzz-go/feature-add-divisible-by-seven.yaml)
+for the full field list and inline schema.
+
+The starter matrix is intentionally small (proof-of-concept scope from the
+issue plan):
+
+| Fixture | Feature | Validation | Bug-fix | Refactor-only | Ambiguous | Longitudinal |
+|---------|---------|------------|---------|---------------|-----------|--------------|
+| `fizzbuzz-go` | yes | — | — | — | — | — |
+| `calculator-cli-go` | yes | yes | yes | optional | yes | planned |
+| `todo-cli-go` | planned | planned | planned | planned | planned | planned |
+
+## Holdout strategy
+
+Scenarios with `holdout: true` are reserved for benchmark reporting and
+should not be used during prompt tuning. The starter scenarios are all
+`holdout: false`; holdout scenarios will be added once the runner stabilizes.
+
+## Running the v1 benchmark scoring
+
+The benchmark scoring layer is exercised today against synthetic
+run-summary fixtures committed under `fixtures/run-summaries/`:
+
+```text
+npx promptfoo@latest eval -c evals/promptfoo/promptfoo-benchmark.yaml
+```
+
+This validates the schema, deterministic protocol-fidelity checks, commit
+quality checks, and clarification expectation checks against both a clean
+exemplar and a TDD-violating exemplar.
+
+## Running the v0 runner scaffold
+
+The earlier scaffold that exercises the `tdd-run-tests` runner's `eval`-mode
+payload is still here:
+
+```text
+npx promptfoo@latest eval -c evals/promptfoo/promptfooconfig.yaml
+```
+
+## Producing real run-summaries: `tdd-eval-run summarize`
+
+The [`cmd/tdd-eval-run`](../cmd/tdd-eval-run/main.go) command produces a
+deterministic run-summary JSON document by analyzing the git history of a
+workspace against a known baseline ref. It is post-hoc: the agent (or a
+human) does the work in a workspace, then this command derives the summary
+from artifacts.
+
+```text
+go run ./cmd/tdd-eval-run summarize \
+  --workspace ./samples/calculator-cli-go \
+  --baseline baseline \
+  --fixture-id calculator-cli-go \
+  --scenario-id feature-add-subtract-command \
+  --scenario-family feature \
+  --run-mode micro-cycle \
+  --tests-passed-at-end \
+  > run-summary.json
+```
+
+Derived deterministically from `git log baseline..HEAD`:
+
+- `commitCount`, `productionFilesChanged`, `newTestsAdded`
+- `productionChangedBeforeFirstFailingTest`
+- `testAndCodeCommittedTogether`
+- `phaseTransitions` (from RED/GREEN/REFACTOR/COMMIT keywords in commit messages)
+- `failureModes`
+
+Reported by the orchestrator (flags):
+
+- `testsPassedAtEnd`, `testRunCount`, `firstFailingTestName`
+- `clarificationAsked`, `clarificationExpected`
+
+Unit tests for the summarize logic live in
+[`internal/evalrun/summarize_test.go`](../internal/evalrun/summarize_test.go).
+
+## What is intentionally stubbed in v1
+
+- The orchestration layer that drives the agent end-to-end (fixture reset,
+  agent invocation, capturing `clarificationAsked` from the transcript,
+  running the test command and feeding `--tests-passed-at-end` into
+  `tdd-eval-run summarize`). Until it lands, the benchmark Promptfoo config
+  reads pre-produced run-summary JSON files via `vars.summaryPath`; those
+  files can now be produced manually by `tdd-eval-run summarize`.
+- Coverage delta is always `null` until coverage capture is wired in.
+- Longitudinal multi-cycle scoring is scaffolded by the schema but no
+  scenarios of that family exist yet.
+- Multi-baseline materialization (e.g. the `bug-add-overflows-on-int-max`
+  baseline referenced by the bug-fix scenario) is a runner responsibility
+  and is not yet implemented.
+
+## Recommended implementation order (from issue plan)
+
+1. ✅ Define the run-summary JSON schema.
+2. ✅ Add the first real CLI fixture (`calculator-cli-go`).
+3. 🟡 Implement fixture reset + scenario runner plumbing. (Post-hoc
+   summarizer landed via `tdd-eval-run summarize`; live agent runner
+   pending.)
+4. ✅ Score deterministic TDD signals with Promptfoo (against synthetic
+   run-summaries; live runner pending).
+5. ✅ Add one ambiguity scenario and one bug-fix scenario.
+6. ⏳ Add one longitudinal multi-cycle run.

--- a/evals/fixtures/run-summaries/calculator-cli-go/feature-add-subtract-command.bad.json
+++ b/evals/fixtures/run-summaries/calculator-cli-go/feature-add-subtract-command.bad.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "1.0.0",
+  "fixtureId": "calculator-cli-go",
+  "baselineId": "clean",
+  "scenarioId": "feature-add-subtract-command",
+  "scenarioFamily": "feature",
+  "runMode": "micro-cycle",
+  "prompt": "Add a \"subtract\" subcommand to the calc CLI...",
+  "phaseTransitions": [
+    { "phase": "GREEN", "source": "edit" },
+    { "phase": "COMMIT", "source": "commit", "ref": "def456" }
+  ],
+  "clarificationAsked": false,
+  "newTestsAdded": 0,
+  "productionFilesChanged": 1,
+  "productionChangedBeforeFirstFailingTest": true,
+  "testsPassedAtEnd": true,
+  "testRunCount": 1,
+  "commitCount": 1,
+  "testAndCodeCommittedTogether": false,
+  "coverageDelta": null,
+  "failureModes": [
+    "production-before-red",
+    "no-failing-test-observed",
+    "test-and-code-split-commit"
+  ],
+  "notes": "Synthetic exemplar of a TDD-violating run: production code added without a prior failing test and committed without any test."
+}

--- a/evals/fixtures/run-summaries/calculator-cli-go/feature-add-subtract-command.good.json
+++ b/evals/fixtures/run-summaries/calculator-cli-go/feature-add-subtract-command.good.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "1.0.0",
+  "fixtureId": "calculator-cli-go",
+  "baselineId": "clean",
+  "scenarioId": "feature-add-subtract-command",
+  "scenarioFamily": "feature",
+  "runMode": "micro-cycle",
+  "prompt": "Add a \"subtract\" subcommand to the calc CLI...",
+  "phaseTransitions": [
+    { "phase": "RED", "source": "test-run", "atTestRunIndex": 0 },
+    { "phase": "GREEN", "source": "test-run", "atTestRunIndex": 1 },
+    { "phase": "COMMIT", "source": "commit", "ref": "abc123" }
+  ],
+  "clarificationAsked": false,
+  "newTestsAdded": 1,
+  "productionFilesChanged": 1,
+  "productionChangedBeforeFirstFailingTest": false,
+  "testsPassedAtEnd": true,
+  "testRunCount": 2,
+  "firstFailingTestName": "TestSubtract_PrintsDifference",
+  "commitCount": 1,
+  "testAndCodeCommittedTogether": true,
+  "coverageDelta": null,
+  "failureModes": [],
+  "notes": "Synthetic exemplar of a clean RED-GREEN-COMMIT cycle for assertion development."
+}

--- a/evals/promptfoo/README.md
+++ b/evals/promptfoo/README.md
@@ -1,0 +1,19 @@
+# Promptfoo Eval Configs
+
+Two Promptfoo configurations live here:
+
+| Config | Purpose |
+|--------|---------|
+| `promptfooconfig.yaml` | v0 scaffold. Validates that the `tdd-run-tests` runner emits a stable `eval` payload. |
+| `promptfoo-benchmark.yaml` | v1 TDD agent benchmark scoring. Reads run-summary JSON artifacts and scores deterministic protocol-fidelity, commit-quality, and clarification signals. |
+
+Run either from the repository root:
+
+```text
+npx promptfoo@latest eval -c evals/promptfoo/promptfooconfig.yaml
+npx promptfoo@latest eval -c evals/promptfoo/promptfoo-benchmark.yaml
+```
+
+Both configs use Promptfoo Community/local mode only — no hosted features
+are required. See [`../README.md`](../README.md) for the overall benchmark
+architecture and the run-summary JSON contract.

--- a/evals/promptfoo/assertions/clarification-expected.js
+++ b/evals/promptfoo/assertions/clarification-expected.js
@@ -1,0 +1,25 @@
+// Clarification expectation check.
+//
+// Each scenario manifest declares whether the agent should have asked for
+// clarification. This assertion enforces that expectation against the
+// run-summary's clarificationAsked field.
+//
+// Drives the "ambiguous" scenario family but is safe to apply to every
+// scenario because non-ambiguous scenarios set clarificationExpected=false.
+
+module.exports = function assertClarificationExpected(output, context) {
+  const expected = context.vars.clarificationExpected === true;
+  const actual = output.clarificationAsked === true;
+  if (actual === expected) {
+    return {
+      pass: true,
+      score: 1,
+      reason: `Clarification expectation satisfied (expected=${expected}).`,
+    };
+  }
+  return {
+    pass: false,
+    score: 0,
+    reason: `Clarification mismatch: expected=${expected}, observed=${actual}.`,
+  };
+};

--- a/evals/promptfoo/assertions/commit-quality.js
+++ b/evals/promptfoo/assertions/commit-quality.js
@@ -1,0 +1,27 @@
+// Commit quality (15% of the V1 scoring weight).
+//
+// Deterministic checks:
+//   - At least one commit was produced.
+//   - Test and production code were committed together.
+
+module.exports = function assertCommitQuality(output) {
+  if (output.commitCount === 0) {
+    return {
+      pass: false,
+      score: 0,
+      reason: 'No commits were produced during the run.',
+    };
+  }
+  if (output.testAndCodeCommittedTogether !== true) {
+    return {
+      pass: false,
+      score: 0.5,
+      reason: 'Test and production code were committed separately.',
+    };
+  }
+  return {
+    pass: true,
+    score: 1,
+    reason: `${output.commitCount} commit(s) produced with test + production grouped together.`,
+  };
+};

--- a/evals/promptfoo/assertions/detects-production-before-red.js
+++ b/evals/promptfoo/assertions/detects-production-before-red.js
@@ -1,0 +1,12 @@
+module.exports = function assertDetectsProductionBeforeRed(output) {
+  const detected = Array.isArray(output.failureModes)
+    && output.failureModes.includes('production-before-red');
+
+  return {
+    pass: detected,
+    score: detected ? 1 : 0,
+    reason: detected
+      ? 'Detected production-before-red as expected.'
+      : 'Failed to detect production-before-red.',
+  };
+};

--- a/evals/promptfoo/assertions/eval-shape.js
+++ b/evals/promptfoo/assertions/eval-shape.js
@@ -1,0 +1,44 @@
+module.exports = function assertEvalShape(output) {
+  if (!output || typeof output !== 'object') {
+    return {
+      pass: false,
+      score: 0,
+      reason: 'Expected object output from eval provider.',
+    };
+  }
+
+  const requiredKeys = [
+    'event',
+    'framework',
+    'phase',
+    'phaseConstraint',
+    'passed',
+    'failed',
+    'failingTests',
+    'recommendedNextAction',
+    'testExitCode',
+  ];
+
+  const missing = requiredKeys.filter((key) => !(key in output));
+  if (missing.length > 0) {
+    return {
+      pass: false,
+      score: 0,
+      reason: `Missing keys: ${missing.join(', ')}`,
+    };
+  }
+
+  if (output.event !== 'Evaluation' || output.framework !== 'promptfoo') {
+    return {
+      pass: false,
+      score: 0,
+      reason: `Unexpected event/framework: ${output.event}/${output.framework}`,
+    };
+  }
+
+  return {
+    pass: true,
+    score: 1,
+    reason: 'Eval payload exposes the expected Promptfoo schema.',
+  };
+};

--- a/evals/promptfoo/assertions/failure-count.js
+++ b/evals/promptfoo/assertions/failure-count.js
@@ -1,0 +1,16 @@
+module.exports = function assertFailureCount(output, context) {
+  const expected = Number(context.vars.expectedFailed);
+  if (output.failed !== expected) {
+    return {
+      pass: false,
+      score: 0,
+      reason: `Expected failed=${expected}, got ${output.failed}`,
+    };
+  }
+
+  return {
+    pass: true,
+    score: 1,
+    reason: `Failure count matched expected value ${expected}.`,
+  };
+};

--- a/evals/promptfoo/assertions/phase-match.js
+++ b/evals/promptfoo/assertions/phase-match.js
@@ -1,0 +1,16 @@
+module.exports = function assertPhaseMatch(output, context) {
+  const expectedPhase = context.vars.phase;
+  if (output.phase !== expectedPhase) {
+    return {
+      pass: false,
+      score: 0,
+      reason: `Expected phase ${expectedPhase}, got ${output.phase}`,
+    };
+  }
+
+  return {
+    pass: true,
+    score: 1,
+    reason: `Phase matched expected value ${expectedPhase}.`,
+  };
+};

--- a/evals/promptfoo/assertions/protocol-fidelity.js
+++ b/evals/promptfoo/assertions/protocol-fidelity.js
@@ -1,0 +1,43 @@
+// Protocol fidelity (50% of the V1 scoring weight).
+//
+// Deterministic checks derived from the run-summary contract:
+//   - A failing test was observed before any production-code change.
+//   - All tests pass at end of run.
+//   - No "refactor-while-red" failure mode was recorded.
+//   - No "multi-behavior-cycle" failure mode was recorded.
+//
+// Each check contributes equally to the partial score.
+
+module.exports = function assertProtocolFidelity(output) {
+  const checks = [
+    {
+      name: 'red-before-production',
+      pass: output.productionChangedBeforeFirstFailingTest === false,
+    },
+    {
+      name: 'tests-green-at-end',
+      pass: output.testsPassedAtEnd === true,
+    },
+    {
+      name: 'no-refactor-while-red',
+      pass: !output.failureModes.includes('refactor-while-red'),
+    },
+    {
+      name: 'one-behavior-per-cycle',
+      pass: !output.failureModes.includes('multi-behavior-cycle'),
+    },
+  ];
+
+  const passed = checks.filter((c) => c.pass).length;
+  const total = checks.length;
+  const failed = checks.filter((c) => !c.pass).map((c) => c.name);
+
+  return {
+    pass: failed.length === 0,
+    score: passed / total,
+    reason:
+      failed.length === 0
+        ? `Protocol fidelity: ${passed}/${total} checks passed.`
+        : `Protocol fidelity ${passed}/${total}. Failed: ${failed.join(', ')}.`,
+  };
+};

--- a/evals/promptfoo/assertions/run-summary-shape.js
+++ b/evals/promptfoo/assertions/run-summary-shape.js
@@ -1,0 +1,124 @@
+// Validates a run-summary JSON object against the v1 contract from
+// evals/schema/run-summary.schema.json without requiring a JSON-Schema
+// runtime dependency. Keep this in sync with the schema file.
+
+const REQUIRED_KEYS = [
+  'schemaVersion',
+  'fixtureId',
+  'scenarioId',
+  'scenarioFamily',
+  'runMode',
+  'prompt',
+  'phaseTransitions',
+  'clarificationAsked',
+  'newTestsAdded',
+  'productionFilesChanged',
+  'productionChangedBeforeFirstFailingTest',
+  'testsPassedAtEnd',
+  'testRunCount',
+  'commitCount',
+  'testAndCodeCommittedTogether',
+  'failureModes',
+];
+
+const SCENARIO_FAMILIES = new Set([
+  'feature',
+  'validation',
+  'bug-fix',
+  'refactor-only',
+  'ambiguous',
+  'longitudinal',
+]);
+
+const RUN_MODES = new Set(['micro-cycle', 'longitudinal']);
+
+const PHASES = new Set(['RED', 'GREEN', 'REFACTOR', 'COMMIT']);
+
+const PHASE_SOURCES = new Set(['commit', 'hook', 'test-run', 'edit']);
+
+const FAILURE_MODES = new Set([
+  'production-before-red',
+  'no-failing-test-observed',
+  'tests-failing-at-end',
+  'refactor-while-red',
+  'missing-clarification',
+  'multi-behavior-cycle',
+  'test-and-code-split-commit',
+  'no-commit-produced',
+  'harness-error',
+]);
+
+function fail(reason) {
+  return { pass: false, score: 0, reason };
+}
+
+module.exports = function assertRunSummaryShape(output) {
+  if (!output || typeof output !== 'object' || Array.isArray(output)) {
+    return fail('Expected run-summary object output.');
+  }
+
+  const missing = REQUIRED_KEYS.filter((k) => !(k in output));
+  if (missing.length > 0) {
+    return fail(`Missing required keys: ${missing.join(', ')}`);
+  }
+
+  if (output.schemaVersion !== '1.0.0') {
+    return fail(`Unsupported schemaVersion: ${output.schemaVersion}`);
+  }
+  if (!SCENARIO_FAMILIES.has(output.scenarioFamily)) {
+    return fail(`Invalid scenarioFamily: ${output.scenarioFamily}`);
+  }
+  if (!RUN_MODES.has(output.runMode)) {
+    return fail(`Invalid runMode: ${output.runMode}`);
+  }
+
+  if (!Array.isArray(output.phaseTransitions)) {
+    return fail('phaseTransitions must be an array.');
+  }
+  for (const [i, t] of output.phaseTransitions.entries()) {
+    if (!t || typeof t !== 'object') {
+      return fail(`phaseTransitions[${i}] must be an object.`);
+    }
+    if (!PHASES.has(t.phase)) {
+      return fail(`phaseTransitions[${i}].phase invalid: ${t.phase}`);
+    }
+    if (!PHASE_SOURCES.has(t.source)) {
+      return fail(`phaseTransitions[${i}].source invalid: ${t.source}`);
+    }
+  }
+
+  if (!Array.isArray(output.failureModes)) {
+    return fail('failureModes must be an array.');
+  }
+  for (const m of output.failureModes) {
+    if (!FAILURE_MODES.has(m)) {
+      return fail(`Unknown failureMode: ${m}`);
+    }
+  }
+
+  const intFields = [
+    'newTestsAdded',
+    'productionFilesChanged',
+    'testRunCount',
+    'commitCount',
+  ];
+  for (const f of intFields) {
+    if (!Number.isInteger(output[f]) || output[f] < 0) {
+      return fail(`${f} must be a non-negative integer, got ${output[f]}`);
+    }
+  }
+
+  const boolFields = [
+    'clarificationAsked',
+    'productionChangedBeforeFirstFailingTest',
+    'testsPassedAtEnd',
+    'testAndCodeCommittedTogether',
+  ];
+  for (const f of boolFields) {
+    if (typeof output[f] !== 'boolean') {
+      return fail(`${f} must be boolean, got ${typeof output[f]}`);
+    }
+  }
+
+  return { pass: true, score: 1, reason: 'Run-summary matches v1 schema.' };
+};

--- a/evals/promptfoo/benchmark-provider.js
+++ b/evals/promptfoo/benchmark-provider.js
@@ -1,0 +1,60 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function resolveVars(options, context) {
+  const candidate = context || options || {};
+  if (candidate && typeof candidate === 'object' && candidate.vars && typeof candidate.vars === 'object') {
+    return candidate.vars;
+  }
+  if (candidate && typeof candidate === 'object') {
+    return candidate;
+  }
+  return {};
+}
+
+/**
+ * Benchmark provider for the TDD agent eval matrix.
+ *
+ * For v1, the provider reads a pre-produced run-summary JSON file from
+ * `vars.summaryPath` (resolved relative to the repo root) and returns it as
+ * the model output. This lets the deterministic Promptfoo assertions exercise
+ * the scoring layer end-to-end while the agent harness runner is still under
+ * construction.
+ *
+ * Once the harness runner is wired up, this provider will instead invoke the
+ * runner against `vars.fixtureId` + `vars.scenarioId` and return the produced
+ * run-summary JSON.
+ */
+module.exports = class TddBenchmarkProvider {
+  id() {
+    return 'tdd-benchmark-provider';
+  }
+
+  async callApi(_prompt, _options, context) {
+    const repoRoot = path.resolve(__dirname, '..', '..');
+    const vars = resolveVars(_options, context);
+    const summaryPath = vars.summaryPath;
+
+    if (!summaryPath) {
+      throw new Error('benchmark provider requires vars.summaryPath until the harness runner is wired up');
+    }
+
+    const absolute = path.isAbsolute(summaryPath)
+      ? summaryPath
+      : path.join(repoRoot, summaryPath);
+
+    const raw = fs.readFileSync(absolute, 'utf8');
+    const parsed = JSON.parse(raw);
+
+    return {
+      output: parsed,
+      metadata: {
+        summaryPath: absolute,
+        fixtureId: parsed.fixtureId,
+        scenarioId: parsed.scenarioId,
+        scenarioFamily: parsed.scenarioFamily,
+        runMode: parsed.runMode,
+      },
+    };
+  }
+};

--- a/evals/promptfoo/prompt.txt
+++ b/evals/promptfoo/prompt.txt
@@ -1,0 +1,1 @@
+Evaluate the current TDD harness run state.

--- a/evals/promptfoo/promptfoo-benchmark.yaml
+++ b/evals/promptfoo/promptfoo-benchmark.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: |
+  TDD agent benchmark matrix (v1). Scores deterministic protocol-fidelity
+  signals over run-summary JSON artifacts produced by the harness runner.
+
+  For now, the benchmark-provider reads pre-produced run-summary JSON files
+  from evals/fixtures/run-summaries/ so the scoring layer can be exercised
+  end-to-end before the agent runner is wired up. Each `tests` entry models
+  one scenario from one baseline.
+
+providers:
+  - file://./benchmark-provider.js
+
+prompts:
+  - file://./prompt.txt
+
+tests:
+  - description: calculator-cli-go feature-add-subtract-command (clean RED-GREEN-COMMIT exemplar)
+    threshold: 1
+    vars:
+      fixtureId: calculator-cli-go
+      scenarioId: feature-add-subtract-command
+      scenarioFamily: feature
+      runMode: micro-cycle
+      clarificationExpected: false
+      summaryPath: evals/fixtures/run-summaries/calculator-cli-go/feature-add-subtract-command.good.json
+    assert:
+      - type: javascript
+        value: file://./assertions/run-summary-shape.js
+        metric: schema_shape
+      - type: javascript
+        value: file://./assertions/protocol-fidelity.js
+        metric: protocol_fidelity
+      - type: javascript
+        value: file://./assertions/commit-quality.js
+        metric: commit_quality
+      - type: javascript
+        value: file://./assertions/clarification-expected.js
+        metric: clarification
+
+  # Negative exemplar: this run violated TDD discipline. We assert that the
+  # scoring layer detects the expected violation signal.
+  - description: calculator-cli-go feature-add-subtract-command (TDD violation exemplar)
+    threshold: 1
+    vars:
+      fixtureId: calculator-cli-go
+      scenarioId: feature-add-subtract-command
+      scenarioFamily: feature
+      runMode: micro-cycle
+      clarificationExpected: false
+      summaryPath: evals/fixtures/run-summaries/calculator-cli-go/feature-add-subtract-command.bad.json
+    assert:
+      - type: javascript
+        value: file://./assertions/run-summary-shape.js
+        metric: schema_shape
+      - type: javascript
+        value: file://./assertions/detects-production-before-red.js
+        metric: detects_violation
+
+commandLineOptions:
+  cache: false
+  table: true
+
+outputPath: ./results/promptfoo-benchmark.json

--- a/evals/promptfoo/promptfooconfig.yaml
+++ b/evals/promptfoo/promptfooconfig.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: TDD harness evaluation scaffold built on Promptfoo Community/local mode.
+
+providers:
+  - file://./provider.js
+
+prompts:
+  - file://./prompt.txt
+
+defaultTest:
+  threshold: 1
+  assert:
+    - type: javascript
+      value: file://./assertions/eval-shape.js
+      metric: payload_shape
+    - type: javascript
+      value: file://./assertions/phase-match.js
+      metric: phase_consistency
+
+tests:
+  - description: Eval payload is stable for a passing GREEN scenario
+    vars:
+      mode: eval
+      phase: GREEN
+      testCommand: echo passed: 1
+      testWorkingDir: .
+      expectedFailed: 0
+    assert:
+      - type: javascript
+        value: file://./assertions/failure-count.js
+        metric: failure_count
+  - description: Eval payload surfaces a failing RED scenario deterministically
+    vars:
+      mode: eval
+      phase: RED
+      testCommand: echo expected: 1 && echo actual: 0 && echo 1 failed, 0 passed && exit 1
+      testWorkingDir: .
+      expectedFailed: 1
+    assert:
+      - type: javascript
+        value: file://./assertions/failure-count.js
+        metric: failure_count
+
+commandLineOptions:
+  cache: false
+  table: true
+
+outputPath: ./results/promptfoo-eval.json

--- a/evals/promptfoo/provider.js
+++ b/evals/promptfoo/provider.js
@@ -1,0 +1,71 @@
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+const path = require('node:path');
+
+const execFileAsync = promisify(execFile);
+
+function resolveVars(options, context) {
+  const candidate = context || options || {};
+  if (candidate && typeof candidate === 'object' && candidate.vars && typeof candidate.vars === 'object') {
+    return candidate.vars;
+  }
+  if (candidate && typeof candidate === 'object') {
+    return candidate;
+  }
+  return {};
+}
+
+async function runCommand(command, args, cwd, env) {
+  return execFileAsync(command, args, {
+    cwd,
+    env,
+    windowsHide: true,
+  });
+}
+
+async function invokeRunner(repoRoot, mode, env) {
+  if (process.platform === 'win32') {
+    const windowsArgs = ['-NoProfile', '-File', path.join(repoRoot, 'scripts', 'tdd-run-tests.ps1'), mode];
+    try {
+      return await runCommand('pwsh', windowsArgs, repoRoot, env);
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+      return runCommand('powershell', windowsArgs, repoRoot, env);
+    }
+  }
+
+  return runCommand('bash', [path.join(repoRoot, 'scripts', 'tdd-run-tests.sh'), mode], repoRoot, env);
+}
+
+module.exports = class TddRunTestsProvider {
+  id() {
+    return 'tdd-run-tests-provider';
+  }
+
+  async callApi(_prompt, _options, context) {
+    const repoRoot = path.resolve(__dirname, '..', '..');
+    const vars = resolveVars(_options, context);
+    const mode = vars.mode || 'eval';
+    const env = {
+      ...process.env,
+      TDD_PHASE: vars.phase || process.env.TDD_PHASE || '',
+      STOP_HOOK_ACTIVE: String(vars.stopHookActive ?? process.env.STOP_HOOK_ACTIVE ?? ''),
+      TDD_TEST_COMMAND: vars.testCommand || process.env.TDD_TEST_COMMAND || '',
+      TDD_TEST_WORKING_DIR: vars.testWorkingDir || process.env.TDD_TEST_WORKING_DIR || '.',
+    };
+
+    const { stdout, stderr } = await invokeRunner(repoRoot, mode, env);
+    const combinedOutput = `${stdout}${stderr}`.trim();
+    const parsed = JSON.parse(stdout || '{}');
+
+    return {
+      output: parsed,
+      metadata: {
+        mode,
+        rawOutput: combinedOutput,
+      },
+    };
+  }
+};

--- a/evals/scenarios/calculator-cli-go/ambiguous-multiply-precision.yaml
+++ b/evals/scenarios/calculator-cli-go/ambiguous-multiply-precision.yaml
@@ -1,0 +1,21 @@
+id: ambiguous-multiply-precision
+fixtureId: calculator-cli-go
+baselineId: clean
+family: ambiguous
+runMode: micro-cycle
+prompt: |
+  Add a "multiply" subcommand to the calc CLI. Make sure it handles the
+  expected precision for our users.
+clarificationExpected: true
+expectedConstraints:
+  - The agent must ask at least one clarifying question before producing code.
+  - "Precision" is intentionally ambiguous: the agent should not silently pick integer vs floating-point semantics.
+  - If the agent proceeds without clarification, this scenario is considered failed regardless of test outcome.
+holdout: false
+tags:
+  - cli
+  - ambiguous
+notes: |
+  The prompt is deliberately under-specified. A disciplined TDD agent should
+  surface the ambiguity (integer vs float, overflow handling, decimal places)
+  before writing tests or production code.

--- a/evals/scenarios/calculator-cli-go/bug-fix-add-overflow-regression.yaml
+++ b/evals/scenarios/calculator-cli-go/bug-fix-add-overflow-regression.yaml
@@ -1,0 +1,25 @@
+id: bug-fix-add-overflow-regression
+fixtureId: calculator-cli-go
+baselineId: bug-add-overflows-on-int-max
+family: bug-fix
+runMode: micro-cycle
+prompt: |
+  A regression was reported: `calc add` produces an incorrect (overflowed)
+  result when both arguments equal math.MaxInt32. The repository contains a
+  failing regression test that demonstrates the bug. Make the regression
+  test pass without breaking any existing behavior.
+clarificationExpected: false
+expectedConstraints:
+  - The pre-existing failing regression test must be observed before any production-code change.
+  - No new behaviors should be introduced beyond fixing the regression.
+  - All tests pass at end of run.
+  - Test and production changes are committed together.
+holdout: false
+tags:
+  - cli
+  - bug-fix
+notes: |
+  Baseline `bug-add-overflows-on-int-max` is a variant of the calculator-cli-go
+  fixture that ships with a failing regression test pre-committed. The harness
+  runner is responsible for materializing this baseline. Until the runner is
+  wired up, this scenario is exercised only via synthetic run-summary fixtures.

--- a/evals/scenarios/calculator-cli-go/feature-add-subtract-command.yaml
+++ b/evals/scenarios/calculator-cli-go/feature-add-subtract-command.yaml
@@ -1,0 +1,23 @@
+id: feature-add-subtract-command
+fixtureId: calculator-cli-go
+baselineId: clean
+family: feature
+runMode: micro-cycle
+prompt: |
+  Add a "subtract" subcommand to the calc CLI. It must accept exactly two
+  integer arguments and print "a - b" on stdout. Unknown commands and
+  malformed arguments must continue to exit with code 2. Existing "add"
+  behavior must continue to pass.
+clarificationExpected: false
+expectedConstraints:
+  - A new failing test for "subtract" must appear before any production-code change.
+  - Only one new behavior per RED-GREEN cycle.
+  - All tests pass at end of run.
+  - Test and production changes are committed together.
+  - Existing "add" tests remain green throughout.
+holdout: false
+tags:
+  - cli
+  - feature
+notes: |
+  First "real" CLI feature scenario for the benchmark matrix.

--- a/evals/scenarios/calculator-cli-go/validation-add-rejects-non-integer.yaml
+++ b/evals/scenarios/calculator-cli-go/validation-add-rejects-non-integer.yaml
@@ -1,0 +1,23 @@
+id: validation-add-rejects-non-integer
+fixtureId: calculator-cli-go
+baselineId: clean
+family: validation
+runMode: micro-cycle
+prompt: |
+  Improve the "add" subcommand so that when either argument is not a valid
+  integer, the CLI prints a clear error message that includes the offending
+  argument and exits with code 2. Existing successful "add" behavior must
+  continue to pass.
+clarificationExpected: false
+expectedConstraints:
+  - A new failing test that asserts the error message and exit code must appear before any production-code change.
+  - Only one new behavior per RED-GREEN cycle.
+  - All tests pass at end of run.
+  - Test and production changes are committed together.
+holdout: false
+tags:
+  - cli
+  - validation
+notes: |
+  Exercises validation-edge handling on top of a baseline that already
+  exits 2 on non-integers but does not surface the offending value.

--- a/evals/scenarios/fizzbuzz-go/feature-add-divisible-by-seven.yaml
+++ b/evals/scenarios/fizzbuzz-go/feature-add-divisible-by-seven.yaml
@@ -1,0 +1,44 @@
+# Scenario manifest schema (v1, informal)
+#
+# Each scenario file describes a single evaluation unit:
+#   one scenario from one known baseline.
+#
+# Required fields:
+#   id                  Stable identifier within the fixture.
+#   fixtureId           Matches a directory under samples/.
+#   baselineId          Identifier for the clean snapshot to start from.
+#   family              One of: feature | validation | bug-fix |
+#                       refactor-only | ambiguous | longitudinal
+#   runMode             One of: micro-cycle | longitudinal
+#   prompt              User prompt sent to the agent (verbatim).
+#   clarificationExpected  Whether the agent should ask for clarification
+#                          before producing code.
+#   expectedConstraints Human-readable list of TDD constraints to hold.
+#   holdout             true if this scenario is reserved for benchmark
+#                       reporting (do not tune prompts against it).
+#
+# Optional fields:
+#   tags                Free-form labels.
+#   notes               Human notes for scenario authors.
+id: feature-add-divisible-by-seven
+fixtureId: fizzbuzz-go
+baselineId: clean
+family: feature
+runMode: micro-cycle
+prompt: |
+  Extend FizzBuzz so that numbers divisible by 7 (but not by 3 or 5) return
+  "Bazz". Numbers divisible by 3 and 7 should return "FizzBazz". Numbers
+  divisible by 5 and 7 should return "BuzzBazz". Numbers divisible by 3, 5,
+  and 7 should return "FizzBuzzBazz". Existing behavior must continue to
+  pass.
+clarificationExpected: false
+expectedConstraints:
+  - A new failing test must appear before any production-code change.
+  - Only one new behavior per RED-GREEN cycle.
+  - All tests pass at end of run.
+  - Test and production changes are committed together.
+holdout: false
+tags:
+  - smoke
+notes: |
+  Smoke-level scenario only. Do not over-index on fizzbuzz fidelity.

--- a/evals/schema/run-summary.schema.json
+++ b/evals/schema/run-summary.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mrlarson2007/copilot-tdd-harness/evals/schema/run-summary.schema.json",
+  "title": "TDD Agent Run Summary",
+  "description": "Artifact-derived summary of a single TDD agent benchmark run. This is the contract between the harness runner (which drives the agent and captures artifacts) and Promptfoo (which scores the run). Prefer artifact-derived facts over model self-report.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "fixtureId",
+    "scenarioId",
+    "scenarioFamily",
+    "runMode",
+    "prompt",
+    "phaseTransitions",
+    "clarificationAsked",
+    "newTestsAdded",
+    "productionFilesChanged",
+    "productionChangedBeforeFirstFailingTest",
+    "testsPassedAtEnd",
+    "testRunCount",
+    "commitCount",
+    "testAndCodeCommittedTogether",
+    "failureModes"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "1.0.0",
+      "description": "Run-summary schema version. Bump on breaking changes."
+    },
+    "fixtureId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier for the fixture family directory, e.g. 'fizzbuzz-go', 'calculator-cli-go', 'todo-cli-go'."
+    },
+    "baselineId": {
+      "type": "string",
+      "description": "Identifier for the clean baseline snapshot used to start the run (e.g. git tag or directory name)."
+    },
+    "scenarioId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier for the scenario within the fixture, e.g. 'feature-add-divisible-by-seven'."
+    },
+    "scenarioFamily": {
+      "type": "string",
+      "enum": [
+        "feature",
+        "validation",
+        "bug-fix",
+        "refactor-only",
+        "ambiguous",
+        "longitudinal"
+      ],
+      "description": "Behavioral pressure family applied by this scenario."
+    },
+    "runMode": {
+      "type": "string",
+      "enum": ["micro-cycle", "longitudinal"],
+      "description": "Single-cycle discipline run vs. multi-cycle drift run."
+    },
+    "prompt": {
+      "type": "string",
+      "description": "User prompt sent to the agent for this scenario (verbatim)."
+    },
+    "phaseTransitions": {
+      "type": "array",
+      "description": "Ordered phase transitions observed during the run, derived from commits/hook events. Each entry records the phase entered and the artifact source.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["phase", "source"],
+        "properties": {
+          "phase": {
+            "type": "string",
+            "enum": ["RED", "GREEN", "REFACTOR", "COMMIT"]
+          },
+          "source": {
+            "type": "string",
+            "enum": ["commit", "hook", "test-run", "edit"],
+            "description": "Where this transition was observed."
+          },
+          "ref": {
+            "type": "string",
+            "description": "Optional reference (commit sha, hook event id, etc.)."
+          },
+          "atTestRunIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Optional index into the testRunCount sequence when this transition was observed."
+          }
+        }
+      }
+    },
+    "clarificationAsked": {
+      "type": "boolean",
+      "description": "True iff the agent asked the user a clarifying question before producing code."
+    },
+    "newTestsAdded": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of new test cases added during the run, derived from test files diff."
+    },
+    "productionFilesChanged": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of production (non-test) files modified during the run."
+    },
+    "productionChangedBeforeFirstFailingTest": {
+      "type": "boolean",
+      "description": "True iff any production-code edit was committed or saved before the first failing test appeared. This is the central RED-before-production fidelity signal."
+    },
+    "testsPassedAtEnd": {
+      "type": "boolean",
+      "description": "True iff the configured test command exited 0 at the end of the run."
+    },
+    "testRunCount": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of times the test command was executed during the run."
+    },
+    "firstFailingTestName": {
+      "type": "string",
+      "description": "Name of the first failing test observed during the run, if any."
+    },
+    "commitCount": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of commits produced during the run."
+    },
+    "testAndCodeCommittedTogether": {
+      "type": "boolean",
+      "description": "True iff every commit that touches production code also touches the corresponding test file (or vice versa). Vacuously true when commitCount is 0."
+    },
+    "coverageDelta": {
+      "type": ["number", "null"],
+      "description": "Optional change in line coverage for changed files (post - pre). Null when coverage is unavailable."
+    },
+    "failureModes": {
+      "type": "array",
+      "description": "Structured list of detected fidelity failures. Empty array means no failures detected.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "production-before-red",
+          "no-failing-test-observed",
+          "tests-failing-at-end",
+          "refactor-while-red",
+          "missing-clarification",
+          "multi-behavior-cycle",
+          "test-and-code-split-commit",
+          "no-commit-produced",
+          "harness-error"
+        ]
+      }
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional free-form notes from the harness runner. Not used for scoring."
+    }
+  }
+}

--- a/internal/evalrun/summarize.go
+++ b/internal/evalrun/summarize.go
@@ -1,0 +1,392 @@
+// Package evalrun produces a deterministic run-summary JSON document from a
+// completed TDD agent run, by analyzing the git history of a workspace
+// against a known baseline ref.
+//
+// The package is intentionally small and dependency-free. It is not a live
+// agent runner: it post-processes a workspace where the agent (or a human)
+// has already done the work. This lets the same artifact-derived schema
+// drive both manual and automated runs.
+package evalrun
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SchemaVersion is the run-summary schema version produced by this package.
+const SchemaVersion = "1.0.0"
+
+// Opts controls a single Summarize invocation.
+type Opts struct {
+	// WorkspaceDir is the path to the git working tree containing the run.
+	WorkspaceDir string
+	// BaselineRef is the git ref (sha, tag, branch) at which the run started.
+	// Commits in BaselineRef..HEAD are considered "the run".
+	BaselineRef string
+
+	// Scenario context, copied verbatim into the summary.
+	FixtureID      string
+	BaselineID     string
+	ScenarioID     string
+	ScenarioFamily string
+	RunMode        string
+	Prompt         string
+
+	// ClarificationAsked is reported by the orchestrator (true iff the agent
+	// asked a clarifying question before producing code).
+	ClarificationAsked bool
+	// ClarificationExpected is taken from the scenario manifest. When true
+	// and ClarificationAsked is false, the "missing-clarification" failure
+	// mode is recorded.
+	ClarificationExpected bool
+
+	// TestFilePatterns are filename glob patterns (matched on basename) that
+	// classify a file as a test file. Default: ["*_test.go"].
+	TestFilePatterns []string
+
+	// NewTestPatterns are regular-expression-free substring markers used to
+	// count newly added test cases inside test files. Default: ["func Test"].
+	// A line counts when it appears as an added line in a unified diff and
+	// contains one of these markers.
+	NewTestPatterns []string
+
+	// TestsPassedAtEnd is the verified test outcome at HEAD, reported by the
+	// orchestrator after running the configured test command.
+	TestsPassedAtEnd bool
+	// TestRunCount is the number of test executions observed during the run,
+	// reported by the orchestrator.
+	TestRunCount int
+	// FirstFailingTestName is optionally reported by the orchestrator.
+	FirstFailingTestName string
+
+	// Notes is optional free-form notes that pass through to the summary.
+	Notes string
+}
+
+// PhaseTransition mirrors the schema entry.
+type PhaseTransition struct {
+	Phase          string `json:"phase"`
+	Source         string `json:"source"`
+	Ref            string `json:"ref,omitempty"`
+	AtTestRunIndex *int   `json:"atTestRunIndex,omitempty"`
+}
+
+// RunSummary mirrors evals/schema/run-summary.schema.json (v1.0.0).
+type RunSummary struct {
+	SchemaVersion                            string            `json:"schemaVersion"`
+	FixtureID                                string            `json:"fixtureId"`
+	BaselineID                               string            `json:"baselineId,omitempty"`
+	ScenarioID                               string            `json:"scenarioId"`
+	ScenarioFamily                           string            `json:"scenarioFamily"`
+	RunMode                                  string            `json:"runMode"`
+	Prompt                                   string            `json:"prompt"`
+	PhaseTransitions                         []PhaseTransition `json:"phaseTransitions"`
+	ClarificationAsked                       bool              `json:"clarificationAsked"`
+	NewTestsAdded                            int               `json:"newTestsAdded"`
+	ProductionFilesChanged                   int               `json:"productionFilesChanged"`
+	ProductionChangedBeforeFirstFailingTest  bool              `json:"productionChangedBeforeFirstFailingTest"`
+	TestsPassedAtEnd                         bool              `json:"testsPassedAtEnd"`
+	TestRunCount                             int               `json:"testRunCount"`
+	FirstFailingTestName                     string            `json:"firstFailingTestName,omitempty"`
+	CommitCount                              int               `json:"commitCount"`
+	TestAndCodeCommittedTogether             bool              `json:"testAndCodeCommittedTogether"`
+	CoverageDelta                            *float64          `json:"coverageDelta"`
+	FailureModes                             []string          `json:"failureModes"`
+	Notes                                    string            `json:"notes,omitempty"`
+}
+
+// Summarize analyzes the workspace's git history and produces a run-summary.
+func Summarize(opts Opts) (RunSummary, error) {
+	if opts.WorkspaceDir == "" {
+		return RunSummary{}, fmt.Errorf("WorkspaceDir is required")
+	}
+	if opts.BaselineRef == "" {
+		return RunSummary{}, fmt.Errorf("BaselineRef is required")
+	}
+	if len(opts.TestFilePatterns) == 0 {
+		opts.TestFilePatterns = []string{"*_test.go"}
+	}
+	if len(opts.NewTestPatterns) == 0 {
+		opts.NewTestPatterns = []string{"func Test"}
+	}
+
+	commits, err := listCommits(opts.WorkspaceDir, opts.BaselineRef)
+	if err != nil {
+		return RunSummary{}, fmt.Errorf("list commits: %w", err)
+	}
+
+	commitInfos := make([]commitInfo, 0, len(commits))
+	for _, sha := range commits {
+		info, err := describeCommit(opts.WorkspaceDir, sha, opts.TestFilePatterns)
+		if err != nil {
+			return RunSummary{}, fmt.Errorf("describe commit %s: %w", sha, err)
+		}
+		commitInfos = append(commitInfos, info)
+	}
+
+	prodFiles, testFiles, err := changedFilesSinceBaseline(opts.WorkspaceDir, opts.BaselineRef, opts.TestFilePatterns)
+	if err != nil {
+		return RunSummary{}, fmt.Errorf("changed files: %w", err)
+	}
+
+	newTests, err := countAddedTests(opts.WorkspaceDir, opts.BaselineRef, testFiles, opts.NewTestPatterns)
+	if err != nil {
+		return RunSummary{}, fmt.Errorf("count added tests: %w", err)
+	}
+
+	prodBeforeRed := computeProductionBeforeRed(commitInfos)
+	togetherCommits := computeTestAndCodeTogether(commitInfos)
+	transitions := computePhaseTransitions(commitInfos)
+
+	failureModes := []string{}
+	if prodBeforeRed {
+		failureModes = append(failureModes, "production-before-red")
+	}
+	if !anyTestModified(commitInfos) && newTests == 0 {
+		failureModes = append(failureModes, "no-failing-test-observed")
+	}
+	if !opts.TestsPassedAtEnd {
+		failureModes = append(failureModes, "tests-failing-at-end")
+	}
+	if !togetherCommits {
+		failureModes = append(failureModes, "test-and-code-split-commit")
+	}
+	if len(commitInfos) == 0 {
+		failureModes = append(failureModes, "no-commit-produced")
+	}
+	if opts.ClarificationExpected && !opts.ClarificationAsked {
+		failureModes = append(failureModes, "missing-clarification")
+	}
+
+	testRunCount := opts.TestRunCount
+	if testRunCount == 0 {
+		// Conservative default when the orchestrator did not report a count.
+		testRunCount = len(commitInfos)
+	}
+
+	return RunSummary{
+		SchemaVersion:                           SchemaVersion,
+		FixtureID:                               opts.FixtureID,
+		BaselineID:                              opts.BaselineID,
+		ScenarioID:                              opts.ScenarioID,
+		ScenarioFamily:                          opts.ScenarioFamily,
+		RunMode:                                 opts.RunMode,
+		Prompt:                                  opts.Prompt,
+		PhaseTransitions:                        transitions,
+		ClarificationAsked:                      opts.ClarificationAsked,
+		NewTestsAdded:                           newTests,
+		ProductionFilesChanged:                  len(prodFiles),
+		ProductionChangedBeforeFirstFailingTest: prodBeforeRed,
+		TestsPassedAtEnd:                        opts.TestsPassedAtEnd,
+		TestRunCount:                            testRunCount,
+		FirstFailingTestName:                    opts.FirstFailingTestName,
+		CommitCount:                             len(commitInfos),
+		TestAndCodeCommittedTogether:            togetherCommits,
+		CoverageDelta:                           nil,
+		FailureModes:                            failureModes,
+		Notes:                                   opts.Notes,
+	}, nil
+}
+
+// MarshalJSON returns the canonical JSON encoding of a run-summary.
+func MarshalJSON(s RunSummary) ([]byte, error) {
+	return json.MarshalIndent(s, "", "  ")
+}
+
+type commitInfo struct {
+	SHA            string
+	Message        string
+	ChangedFiles   []string
+	TestFiles      []string
+	ProdFiles      []string
+}
+
+func listCommits(workspace, baseline string) ([]string, error) {
+	out, err := runGit(workspace, "log", "--reverse", "--pretty=%H", baseline+"..HEAD")
+	if err != nil {
+		return nil, err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
+}
+
+func describeCommit(workspace, sha string, testPatterns []string) (commitInfo, error) {
+	msg, err := runGit(workspace, "log", "-1", "--pretty=%s", sha)
+	if err != nil {
+		return commitInfo{}, err
+	}
+	files, err := runGit(workspace, "show", "--name-only", "--pretty=", sha)
+	if err != nil {
+		return commitInfo{}, err
+	}
+	info := commitInfo{
+		SHA:     sha,
+		Message: strings.TrimSpace(msg),
+	}
+	for _, line := range strings.Split(strings.TrimSpace(files), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		info.ChangedFiles = append(info.ChangedFiles, line)
+		if isTestFile(line, testPatterns) {
+			info.TestFiles = append(info.TestFiles, line)
+		} else {
+			info.ProdFiles = append(info.ProdFiles, line)
+		}
+	}
+	return info, nil
+}
+
+func changedFilesSinceBaseline(workspace, baseline string, testPatterns []string) (prodFiles, testFiles []string, err error) {
+	out, err := runGit(workspace, "diff", "--name-only", baseline+"..HEAD")
+	if err != nil {
+		return nil, nil, err
+	}
+	prodSet := map[string]struct{}{}
+	testSet := map[string]struct{}{}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if isTestFile(line, testPatterns) {
+			testSet[line] = struct{}{}
+		} else {
+			prodSet[line] = struct{}{}
+		}
+	}
+	prodFiles = sortedKeys(prodSet)
+	testFiles = sortedKeys(testSet)
+	return prodFiles, testFiles, nil
+}
+
+func countAddedTests(workspace, baseline string, testFiles []string, markers []string) (int, error) {
+	if len(testFiles) == 0 {
+		return 0, nil
+	}
+	args := []string{"diff", "--unified=0", baseline + "..HEAD", "--"}
+	args = append(args, testFiles...)
+	out, err := runGit(workspace, args...)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "+") || strings.HasPrefix(line, "+++") {
+			continue
+		}
+		body := line[1:]
+		for _, marker := range markers {
+			if strings.Contains(body, marker) {
+				count++
+				break
+			}
+		}
+	}
+	return count, nil
+}
+
+func computeProductionBeforeRed(commits []commitInfo) bool {
+	// Walk commits chronologically (listCommits already used --reverse).
+	// If any commit modifies production files before the first commit that
+	// modifies a test file, flag it.
+	for _, c := range commits {
+		if len(c.TestFiles) > 0 {
+			return false
+		}
+		if len(c.ProdFiles) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func computeTestAndCodeTogether(commits []commitInfo) bool {
+	if len(commits) == 0 {
+		return true // vacuously true
+	}
+	for _, c := range commits {
+		if len(c.ProdFiles) > 0 && len(c.TestFiles) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func computePhaseTransitions(commits []commitInfo) []PhaseTransition {
+	transitions := []PhaseTransition{}
+	for _, c := range commits {
+		phase := phaseFromMessage(c.Message)
+		if phase == "" {
+			continue
+		}
+		transitions = append(transitions, PhaseTransition{
+			Phase:  phase,
+			Source: "commit",
+			Ref:    c.SHA,
+		})
+	}
+	return transitions
+}
+
+func phaseFromMessage(msg string) string {
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "red"):
+		return "RED"
+	case strings.Contains(lower, "green"):
+		return "GREEN"
+	case strings.Contains(lower, "refactor"):
+		return "REFACTOR"
+	case strings.Contains(lower, "commit"):
+		return "COMMIT"
+	default:
+		return ""
+	}
+}
+
+func anyTestModified(commits []commitInfo) bool {
+	for _, c := range commits {
+		if len(c.TestFiles) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func isTestFile(path string, patterns []string) bool {
+	base := filepath.Base(path)
+	for _, p := range patterns {
+		if ok, _ := filepath.Match(p, base); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func runGit(workspace string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = workspace
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}

--- a/internal/evalrun/summarize_test.go
+++ b/internal/evalrun/summarize_test.go
@@ -1,0 +1,251 @@
+package evalrun
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gitRepo is a tiny test helper for building synthetic git histories.
+type gitRepo struct {
+	t   *testing.T
+	dir string
+}
+
+func newGitRepo(t *testing.T) *gitRepo {
+	t.Helper()
+	dir := t.TempDir()
+	r := &gitRepo{t: t, dir: dir}
+	r.run("git", "init", "-q", "-b", "main")
+	r.run("git", "config", "user.email", "tdd@example.com")
+	r.run("git", "config", "user.name", "TDD Test")
+	r.run("git", "config", "commit.gpgsign", "false")
+	return r
+}
+
+func (r *gitRepo) run(name string, args ...string) string {
+	r.t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = r.dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		r.t.Fatalf("%s %s: %v (%s)", name, strings.Join(args, " "), err, string(out))
+	}
+	return string(out)
+}
+
+func (r *gitRepo) write(rel, body string) {
+	r.t.Helper()
+	full := filepath.Join(r.dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		r.t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		r.t.Fatalf("write: %v", err)
+	}
+}
+
+func (r *gitRepo) commit(msg string, paths ...string) {
+	r.t.Helper()
+	args := append([]string{"add", "--"}, paths...)
+	r.run("git", args...)
+	r.run("git", "commit", "-q", "-m", msg)
+}
+
+func (r *gitRepo) tag(name string) {
+	r.t.Helper()
+	r.run("git", "tag", name)
+}
+
+func TestSummarize_CleanRedGreenCommitFlow_NoFailureModes(t *testing.T) {
+	repo := newGitRepo(t)
+	repo.write("calc.go", "package calc\n")
+	repo.write("README.md", "baseline\n")
+	repo.commit("chore: baseline", "calc.go", "README.md")
+	repo.tag("baseline")
+
+	repo.write("calc_test.go", "package calc\n\nfunc TestSubtract(t *testing.T) {}\n")
+	repo.write("calc.go", "package calc\n\nfunc Subtract(a, b int) int { return a - b }\n")
+	repo.commit("RED-GREEN: subtract", "calc_test.go", "calc.go")
+
+	got, err := Summarize(Opts{
+		WorkspaceDir:     repo.dir,
+		BaselineRef:      "baseline",
+		FixtureID:        "calc",
+		ScenarioID:       "feature-subtract",
+		ScenarioFamily:   "feature",
+		RunMode:          "micro-cycle",
+		Prompt:           "Add subtract.",
+		TestsPassedAtEnd: true,
+		TestRunCount:     2,
+	})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+
+	if got.CommitCount != 1 {
+		t.Errorf("CommitCount = %d, want 1", got.CommitCount)
+	}
+	if got.NewTestsAdded != 1 {
+		t.Errorf("NewTestsAdded = %d, want 1", got.NewTestsAdded)
+	}
+	if got.ProductionFilesChanged != 1 {
+		t.Errorf("ProductionFilesChanged = %d, want 1", got.ProductionFilesChanged)
+	}
+	if got.ProductionChangedBeforeFirstFailingTest {
+		t.Errorf("ProductionChangedBeforeFirstFailingTest = true, want false")
+	}
+	if !got.TestAndCodeCommittedTogether {
+		t.Errorf("TestAndCodeCommittedTogether = false, want true")
+	}
+	if len(got.FailureModes) != 0 {
+		t.Errorf("FailureModes = %v, want empty", got.FailureModes)
+	}
+	if len(got.PhaseTransitions) != 1 || got.PhaseTransitions[0].Phase != "RED" {
+		t.Errorf("PhaseTransitions = %+v, want one RED entry (first match wins)", got.PhaseTransitions)
+	}
+}
+
+func TestSummarize_ProductionBeforeRed_FlagsViolation(t *testing.T) {
+	repo := newGitRepo(t)
+	repo.write("calc.go", "package calc\n")
+	repo.commit("chore: baseline", "calc.go")
+	repo.tag("baseline")
+
+	// Production-only commit before any test.
+	repo.write("calc.go", "package calc\n\nfunc Subtract(a, b int) int { return a - b }\n")
+	repo.commit("feat: subtract", "calc.go")
+
+	// Test added afterwards.
+	repo.write("calc_test.go", "package calc\n\nfunc TestSubtract(t *testing.T) {}\n")
+	repo.commit("test: subtract", "calc_test.go")
+
+	got, err := Summarize(Opts{
+		WorkspaceDir:     repo.dir,
+		BaselineRef:      "baseline",
+		FixtureID:        "calc",
+		ScenarioID:       "feature-subtract",
+		ScenarioFamily:   "feature",
+		RunMode:          "micro-cycle",
+		Prompt:           "Add subtract.",
+		TestsPassedAtEnd: true,
+	})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+
+	if !got.ProductionChangedBeforeFirstFailingTest {
+		t.Errorf("ProductionChangedBeforeFirstFailingTest = false, want true")
+	}
+	if got.TestAndCodeCommittedTogether {
+		t.Errorf("TestAndCodeCommittedTogether = true, want false")
+	}
+	if !contains(got.FailureModes, "production-before-red") {
+		t.Errorf("FailureModes missing production-before-red: %v", got.FailureModes)
+	}
+	if !contains(got.FailureModes, "test-and-code-split-commit") {
+		t.Errorf("FailureModes missing test-and-code-split-commit: %v", got.FailureModes)
+	}
+}
+
+func TestSummarize_NoCommits_VacuouslyTogetherButFlagged(t *testing.T) {
+	repo := newGitRepo(t)
+	repo.write("calc.go", "package calc\n")
+	repo.commit("chore: baseline", "calc.go")
+	repo.tag("baseline")
+
+	got, err := Summarize(Opts{
+		WorkspaceDir:     repo.dir,
+		BaselineRef:      "baseline",
+		FixtureID:        "calc",
+		ScenarioID:       "feature-subtract",
+		ScenarioFamily:   "feature",
+		RunMode:          "micro-cycle",
+		TestsPassedAtEnd: true,
+	})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+
+	if got.CommitCount != 0 {
+		t.Errorf("CommitCount = %d, want 0", got.CommitCount)
+	}
+	if !got.TestAndCodeCommittedTogether {
+		t.Errorf("TestAndCodeCommittedTogether = false, want vacuously true")
+	}
+	if !contains(got.FailureModes, "no-commit-produced") {
+		t.Errorf("FailureModes missing no-commit-produced: %v", got.FailureModes)
+	}
+	if !contains(got.FailureModes, "no-failing-test-observed") {
+		t.Errorf("FailureModes missing no-failing-test-observed: %v", got.FailureModes)
+	}
+}
+
+func TestSummarize_TestsFailingAtEnd_RecordsFailureMode(t *testing.T) {
+	repo := newGitRepo(t)
+	repo.write("calc.go", "package calc\n")
+	repo.commit("chore: baseline", "calc.go")
+	repo.tag("baseline")
+
+	repo.write("calc_test.go", "package calc\n\nfunc TestSubtract(t *testing.T) {}\n")
+	repo.write("calc.go", "package calc\n\nfunc Subtract(a, b int) int { return 0 }\n")
+	repo.commit("RED-GREEN: subtract", "calc_test.go", "calc.go")
+
+	got, err := Summarize(Opts{
+		WorkspaceDir:     repo.dir,
+		BaselineRef:      "baseline",
+		FixtureID:        "calc",
+		ScenarioID:       "feature-subtract",
+		ScenarioFamily:   "feature",
+		RunMode:          "micro-cycle",
+		TestsPassedAtEnd: false,
+	})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+
+	if !contains(got.FailureModes, "tests-failing-at-end") {
+		t.Errorf("FailureModes missing tests-failing-at-end: %v", got.FailureModes)
+	}
+}
+
+func TestSummarize_MissingClarification_FlaggedWhenExpected(t *testing.T) {
+	repo := newGitRepo(t)
+	repo.write("calc.go", "package calc\n")
+	repo.commit("chore: baseline", "calc.go")
+	repo.tag("baseline")
+
+	repo.write("calc_test.go", "package calc\n\nfunc TestMultiply(t *testing.T) {}\n")
+	repo.write("calc.go", "package calc\n\nfunc Multiply(a, b int) int { return a * b }\n")
+	repo.commit("RED-GREEN: multiply", "calc_test.go", "calc.go")
+
+	got, err := Summarize(Opts{
+		WorkspaceDir:          repo.dir,
+		BaselineRef:           "baseline",
+		FixtureID:             "calc",
+		ScenarioID:            "ambiguous-multiply",
+		ScenarioFamily:        "ambiguous",
+		RunMode:               "micro-cycle",
+		ClarificationExpected: true,
+		ClarificationAsked:    false,
+		TestsPassedAtEnd:      true,
+	})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+
+	if !contains(got.FailureModes, "missing-clarification") {
+		t.Errorf("FailureModes missing missing-clarification: %v", got.FailureModes)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tddruntests/core.go
+++ b/internal/tddruntests/core.go
@@ -14,6 +14,7 @@ const (
 	ModeTerminal Mode = "terminal"
 	ModeState    Mode = "state"
 	ModeStatus   Mode = "status"
+	ModeEval     Mode = "eval"
 )
 
 type State struct {
@@ -70,6 +71,8 @@ func ParseMode(value string) (Mode, bool) {
 		return ModeTerminal, true
 	case string(ModeState):
 		return ModeState, true
+	case string(ModeEval):
+		return ModeEval, true
 	case string(ModeStatus), "":
 		return ModeStatus, true
 	default:
@@ -284,11 +287,34 @@ func BuildPayload(mode Mode, input PayloadInput) map[string]any {
 			"testWorkingDir":        input.TestWorkingDir,
 			"testExitCode":          input.State.TestExitCode,
 		}
+	case ModeEval:
+		failingTests := []string{}
+		if input.State.Failed > 0 {
+			failingTests = append(failingTests, input.State.FirstFailureTest)
+		}
+		return map[string]any{
+			"event":                 "Evaluation",
+			"framework":             "promptfoo",
+			"phase":                 input.Phase,
+			"phaseConstraint":       input.PhaseConstraint,
+			"passed":                input.State.Passed,
+			"failed":                input.State.Failed,
+			"failingTests":          failingTests,
+			"expected":              input.State.Expected,
+			"actual":                input.State.Actual,
+			"likelyCause":           input.State.LikelyCause,
+			"reflexion":             input.State.Reflexion,
+			"lastCommittedBehavior": input.LastCommitted,
+			"recommendedNextAction": input.RecommendedNext,
+			"testCommand":           input.TestCommand,
+			"testWorkingDir":        input.TestWorkingDir,
+			"testExitCode":          input.State.TestExitCode,
+		}
 	default:
 		return map[string]any{
 			"event":    "Error",
 			"decision": "continue",
-			"message":  "Unsupported mode: " + string(mode) + ". Supported modes are hint, step, terminal, state, status.",
+			"message":  "Unsupported mode: " + string(mode) + ". Supported modes are hint, step, terminal, state, status, eval.",
 		}
 	}
 }

--- a/internal/tddruntests/core_test.go
+++ b/internal/tddruntests/core_test.go
@@ -94,3 +94,41 @@ func TestResolveStopHookActive_WhenSetToYes_ShouldEnableGuard(t *testing.T) {
 		t.Fatal("expected yes to enable stop hook guard")
 	}
 }
+
+func TestBuildPayload_WhenModeEval_ShouldEmitPromptfooSchema(t *testing.T) {
+	payload := BuildPayload(Mode("eval"), PayloadInput{
+		Phase:           "GREEN",
+		PhaseConstraint: "write only the minimal production code needed to make the failing test pass.",
+		State: State{
+			Passed:           3,
+			Failed:           1,
+			FirstFailureTest: "WhenInputIsZero_ShouldReturnErr",
+			Expected:         "1",
+			Actual:           "0",
+			LikelyCause:      "assertion mismatch indicates current behavior differs from test expectation",
+			Reflexion:        "REFLEXION: WhenInputIsZero_ShouldReturnErr failed.",
+			TestExitCode:     1,
+		},
+		LastCommitted:   "GREEN: handle zero input",
+		RecommendedNext: "Continue GREEN phase: make the failing test pass with the minimal production change.",
+		TestCommand:     "go test ./...",
+		TestWorkingDir:  ".",
+	})
+
+	if payload["event"] != "Evaluation" {
+		t.Fatalf("expected Evaluation event, got %v", payload["event"])
+	}
+	if payload["framework"] != "promptfoo" {
+		t.Fatalf("expected promptfoo framework, got %v", payload["framework"])
+	}
+	if payload["phase"] != "GREEN" {
+		t.Fatalf("expected GREEN phase, got %v", payload["phase"])
+	}
+	failingTests := payload["failingTests"].([]string)
+	if len(failingTests) != 1 || failingTests[0] != "WhenInputIsZero_ShouldReturnErr" {
+		t.Fatalf("unexpected failing tests payload: %#v", failingTests)
+	}
+	if payload["recommendedNextAction"] == "" {
+		t.Fatal("expected recommended next action in eval payload")
+	}
+}

--- a/samples/calculator-cli-go/README.md
+++ b/samples/calculator-cli-go/README.md
@@ -1,0 +1,33 @@
+# calculator-cli-go
+
+Baseline fixture for the TDD agent benchmark matrix (issue #10).
+
+## Purpose
+
+This fixture is the first "real" CLI benchmark target. It exercises:
+
+- argument parsing
+- exit codes
+- multiple subcommands
+- input validation
+
+It is deliberately small at baseline so that scenarios can drive feature
+additions, validation edges, and bug-fix regressions from a known-clean
+starting point.
+
+## Baseline behavior
+
+- `calc add <a> <b>` prints `a + b`.
+- Unknown commands exit with code `2`.
+- Non-integer arguments exit with code `2`.
+
+## Running tests
+
+```text
+go test ./...
+```
+
+## Scenarios
+
+Scenario manifests for this fixture live in
+[`evals/scenarios/calculator-cli-go/`](../../evals/scenarios/calculator-cli-go/).

--- a/samples/calculator-cli-go/calculator.go
+++ b/samples/calculator-cli-go/calculator.go
@@ -1,0 +1,11 @@
+// Package calculator is the baseline for the calculator-cli-go benchmark fixture.
+//
+// The baseline intentionally exposes only a single trivial behavior (Add) so
+// that scenarios can drive new behavior additions, validation handling, and
+// bug-fix regressions from a known-clean starting point.
+package calculator
+
+// Add returns the sum of two integers.
+func Add(a, b int) int {
+	return a + b
+}

--- a/samples/calculator-cli-go/calculator_test.go
+++ b/samples/calculator-cli-go/calculator_test.go
@@ -1,0 +1,12 @@
+package calculator
+
+import "testing"
+
+func TestAdd_ReturnsSumOfTwoIntegers(t *testing.T) {
+	got := Add(2, 3)
+	want := 5
+
+	if got != want {
+		t.Fatalf("expected %d, got %d", want, got)
+	}
+}

--- a/samples/calculator-cli-go/cmd/calc/main.go
+++ b/samples/calculator-cli-go/cmd/calc/main.go
@@ -1,0 +1,38 @@
+// Command calc is the CLI entry point for the calculator-cli-go fixture.
+//
+// The baseline supports only the "add" subcommand. Scenarios drive the
+// addition of further commands, argument validation, and exit-code behavior.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	calculator "samples/calculator-cli-go"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: calc <command> [args...]")
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "add":
+		if len(os.Args) != 4 {
+			fmt.Fprintln(os.Stderr, "usage: calc add <a> <b>")
+			os.Exit(2)
+		}
+		a, errA := strconv.Atoi(os.Args[2])
+		b, errB := strconv.Atoi(os.Args[3])
+		if errA != nil || errB != nil {
+			fmt.Fprintln(os.Stderr, "add: arguments must be integers")
+			os.Exit(2)
+		}
+		fmt.Println(calculator.Add(a, b))
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+		os.Exit(2)
+	}
+}

--- a/samples/calculator-cli-go/go.mod
+++ b/samples/calculator-cli-go/go.mod
@@ -1,0 +1,3 @@
+module samples/calculator-cli-go
+
+go 1.22

--- a/scripts/tdd-run-tests.ps1
+++ b/scripts/tdd-run-tests.ps1
@@ -1,5 +1,5 @@
 param(
-    [ValidateSet("hint", "step", "terminal", "state", "status")]
+    [ValidateSet("hint", "step", "terminal", "state", "status", "eval")]
     [string]$Mode = "status"
 )
 


### PR DESCRIPTION
## Summary
Adds the first working slice of the TDD agent eval benchmark for issue #20.

## What changed
- add the issue #10 eval benchmark plan and update the top-level plan indexes
- extend `tdd-run-tests` with `eval` mode for Promptfoo-backed payload validation
- add the `calculator-cli-go` fixture and starter scenario manifests
- add the v1 run-summary JSON schema plus synthetic good/bad run-summary fixtures
- add Promptfoo benchmark configs, assertions, and custom providers
- add `tdd-eval-run summarize` to derive run-summary JSON deterministically from git history
- add unit tests for `internal/evalrun` and ignore generated `results/` output

## Validation
- `go build ./...`
- `go test ./...`
- `npx --yes promptfoo@0.120.0 eval -c evals/promptfoo/promptfoo-benchmark.yaml`

## Notes
- `promptfoo@latest` currently requires a newer Node runtime than the environment used for validation, so the benchmark was verified with `promptfoo@0.120.0`.

Fixes #20